### PR TITLE
mypage 디자인 수정

### DIFF
--- a/src/app/(default)/login/google/page.tsx
+++ b/src/app/(default)/login/google/page.tsx
@@ -18,6 +18,8 @@ const GoogleCallbackPage: React.FC = () => {
         return;
       }
 
+      const start = Date.now();
+
       try {
         // GET 요청으로 authCode를 쿼리 스트링에 포함하여 서버로 전송
         const data = await handleGoogleLogin(authCode);
@@ -30,11 +32,20 @@ const GoogleCallbackPage: React.FC = () => {
         setAccessToken(accessToken);
         localStorage.setItem('accessToken', accessToken);
 
-        window.location.href = '/main';
       } catch (error) {
         console.error('구글 로그인 실패:', error);
       } finally {
-        setIsLoading(false);
+        const elapsed = Date.now() - start;
+        const MIN_LOADING_TIME = 2000;
+
+        const delay = Math.max(0, MIN_LOADING_TIME - elapsed);
+        setTimeout(() => {
+          setIsLoading(false);
+
+          setTimeout(() => {
+            window.location.href = '/main';
+          }, 200);
+        }, delay);
       }
     };
 

--- a/src/app/(default)/mypage/_component/FavoriteWebtoons.tsx
+++ b/src/app/(default)/mypage/_component/FavoriteWebtoons.tsx
@@ -31,7 +31,7 @@ export default function FavoriteWebtoons() {
 
   return (
     <div>
-      <div className="grid grid-cols-1 mt-10 gap-5">
+      <div className="grid grid-cols-1 mt-[30px] gap-5">
         {currentItems.map((webtoon: FavoriteWebtoon) => (
           <FavoriteWebtoonItem key={webtoon.interestedWebtoonId} {...webtoon} />
         ))}

--- a/src/app/(default)/mypage/storage/page.tsx
+++ b/src/app/(default)/mypage/storage/page.tsx
@@ -1,12 +1,17 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import RecentWorks from '../_component/RecentWorks';
 import FavoriteWebtoons from '../_component/FavoriteWebtoons';
 import Comments from '../_component/Comments';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 export default function StoragePage() {
-  const [selectedTab, setSelectedTab] = useState('recent');
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const tabFromQuery = searchParams.get('tab');
+  const [selectedTab, setSelectedTab] = useState(tabFromQuery || 'recent');
 
   const tabs = [
     { label: '최근 본 웹툰', key: 'recent' },
@@ -14,8 +19,20 @@ export default function StoragePage() {
     { label: '댓글', key: 'comments' },
   ];
 
+  const handleTabClick = (tabKey: string) => {
+    setSelectedTab(tabKey);
+    router.push(`/mypage/storage?tab=${tabKey}`);
+  };
+
+  // 쿼리스트링 변경 시 탭 상태 갱신
+  useEffect(() => {
+    if (tabFromQuery && tabFromQuery !== selectedTab) {
+      setSelectedTab(tabFromQuery);
+    }
+  }, [tabFromQuery]);
+
   return (
-    <div className="mt-[70px]">
+    <div className="mt-[70px] min-h-screen">
       <h1 className="text-xl font-semibold pt-[21px] mb-4">보관함</h1>
       <div className="flex -ml-6 -mr-[23px] pl-6 pr-[23px] border-b border-b-line">
         {tabs.map((tab) => (
@@ -26,7 +43,7 @@ export default function StoragePage() {
                 ? 'text-brand-yellow border-b-brand-yellow text-[15px] border-b-2'
                 : 'text-[#888888] text-[15px]'
             }`}
-            onClick={() => setSelectedTab(tab.key)}
+            onClick={() => handleTabClick(tab.key)}
           >
             {tab.label}
           </button>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 구글 로그인 시 최소 2초 동안 로딩 화면이 유지되어 더 부드러운 사용자 경험을 제공합니다.
  - 마이페이지의 즐겨찾는 웹툰 목록 상단 여백이 픽셀 단위로 조정되어 레이아웃이 개선되었습니다.
  - 마이페이지 저장소 탭 선택이 URL 쿼리 파라미터와 동기화되어, 탭 상태가 주소창과 연동됩니다.  
  - 저장소 페이지에 최소 높이 스타일이 적용되어 화면이 더 안정적으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->